### PR TITLE
fix bug with pg driver email uniqueness validation

### DIFF
--- a/lib/users/common.js
+++ b/lib/users/common.js
@@ -15,7 +15,7 @@ const USER_COLLECTION_NAME = exports.USER_COLLECTION_NAME = 'user';
 exports.JWT_SECRET_KEY = process.env.JWT_SECRET_KEY || 'efwpoeiurpoijk123`3asd;lkj32E@#;l3kj3#Eeplk3j34fpoiu-Oiu;lkj';
 
 exports.validateEmailUniqueness = async (req, email, errors) => {
-  if (email && errors.email === undefined && (await req.wrestler.dbDriver.countBy(req.wrestler.resource, { email })) !== 0) {
+  if (email && errors.email === undefined && +(await req.wrestler.dbDriver.countBy(req.wrestler.resource, { email })) !== 0) {
     errors.email = { messages: ['Email already exists'] };
   }
 };


### PR DESCRIPTION
When using the postgres driver and checking email uniqueness, countBy returns a string, which causes it to always say that the email already exists. This change casts the result from countBy to a number, so that it'll work regardless of the database driver being used.